### PR TITLE
ci: Add CircleCI config file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,38 @@
+# Use the latest 2.1 version of CircleCI pipeline process engine.
+# See: https://circleci.com/docs/2.0/configuration-reference
+version: 2.1
+
+# Define a job to be invoked later in a workflow.
+# See: https://circleci.com/docs/2.0/configuration-reference/#jobs
+jobs:
+  test:
+    # Specify the execution environment. You can specify an image from Dockerhub or use one of our Convenience Images from CircleCI's Developer Hub.
+    # See: https://circleci.com/docs/2.0/configuration-reference/#docker-machine-macos-windows-executor
+    docker:
+      - image: cimg/node:10.24.1
+    # Add steps to the job
+    # See: https://circleci.com/docs/2.0/configuration-reference/#steps
+    steps:
+      - checkout
+      - restore_cache:
+          # See the configuration reference documentation for more details on using restore_cache and save_cache steps
+          # https://circleci.com/docs/2.0/configuration-reference/?section=reference#save_cache
+          keys:
+            - node-deps-v1-{{ .Branch }}-{{checksum "package-lock.json"}}
+      - run:
+          name: install packages
+          command: npm ci
+      - save_cache:
+          key: node-deps-v1-{{ .Branch }}-{{checksum "package-lock.json"}}
+          paths:
+            - ~/.npm
+      - run:
+          name: Run Tests
+          command: npm run test
+
+# Invoke jobs via workflows
+# See: https://circleci.com/docs/2.0/configuration-reference/#workflows
+workflows:
+  npm-test:
+    jobs:
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,8 @@ jobs:
       - run:
           name: Run Tests
           command: npm run test
+      - store_test_results:
+          path: ~/junit
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,10 +26,15 @@ jobs:
           key: node-deps-v1-{{ .Branch }}-{{checksum "package-lock.json"}}
           paths:
             - ~/.npm
+      - run: mkdir ~/junit
       - run:
           name: Run Tests
           command: npm run test
+          environment:
+            MOCHA_FILE: ~/junit/test-results.xml
       - store_test_results:
+          path: ~/junit
+      - store_artifacts:
           path: ~/junit
 
 # Invoke jobs via workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,16 +26,16 @@ jobs:
           key: node-deps-v1-{{ .Branch }}-{{checksum "package-lock.json"}}
           paths:
             - ~/.npm
-      - run: mkdir ~/junit
       - run:
           name: Run Tests
           command: npm run test
           environment:
-            MOCHA_FILE: ~/junit/test-results.xml
+            MOCHA_FILE: junit/test-results.xml
+      - run: echo $PWD && ls
       - store_test_results:
-          path: ~/junit
+          path: junit
       - store_artifacts:
-          path: ~/junit
+          path: junit
 
 # Invoke jobs via workflows
 # See: https://circleci.com/docs/2.0/configuration-reference/#workflows

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ typings/
 # next.js build output
 .next
 .vscode/launch.json
+junit*

--- a/.multi.json
+++ b/.multi.json
@@ -1,0 +1,6 @@
+{
+  "reporterEnabled": "spec,mocha-junit-reporter",
+  "mochaJunitReporterReporterOptions": {
+    "mochaFile": "junit/test-result.xml"
+  }
+}

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const port = 8010
 
 const sqlite3 = require('sqlite3').verbose()
 const { open } = require('sqlite')
-
+const logger = require('./src/logger')
 const buildSchemas = require('./src/schemas')
 
 const swaggerUi = require('swagger-ui-express')
@@ -17,6 +17,6 @@ open({
   const app = require('./src/app')(db)
   app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument))
   app.listen(port, () =>
-    console.log(`App started and listening on port ${port}`)
+    logger.info(`App started and listening on port ${port}`)
   )
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1255,6 +1255,12 @@
         }
       }
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc=",
+      "dev": true
+    },
     "cheerio": {
       "version": "1.0.0-rc.10",
       "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.10.tgz",
@@ -1563,6 +1569,12 @@
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=",
+      "dev": true
     },
     "crypto-random-string": {
       "version": "1.0.0",
@@ -3941,6 +3953,25 @@
         "p-defer": "^1.0.0"
       }
     },
+    "md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dev": true,
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "dev": true
+        }
+      }
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -4079,6 +4110,69 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "mocha-junit-reporter": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-2.0.2.tgz",
+      "integrity": "sha512-vYwWq5hh3v1lG0gdQCBxwNipBfvDiAM1PHroQRNp96+2l72e9wEUTw+mzoK+O0SudgfQ7WvTQZ9Nh3qkAYAjfg==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.2.0",
+        "md5": "^2.1.0",
+        "mkdirp": "~0.5.1",
+        "strip-ansi": "^6.0.1",
+        "xml": "^1.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
+      }
+    },
+    "mocha-multi-reporters": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/mocha-multi-reporters/-/mocha-multi-reporters-1.5.1.tgz",
+      "integrity": "sha512-Yb4QJOaGLIcmB0VY7Wif5AjvLMUFAdV57D2TWEva1Y0kU/3LjKpeRVmlMIfuO1SVbauve459kgtIizADqxMWPg==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "lodash": "^4.17.15"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
           "dev": true
         }
       }
@@ -6357,6 +6451,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
       "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+      "dev": true
+    },
+    "xml": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+      "integrity": "sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=",
       "dev": true
     },
     "xmlhttprequest-ssl": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "coverage": "nyc npm run test",
     "lint": "eslint --fix .",
-    "test": "nyc mocha tests",
+    "test": "nyc mocha tests --reporter mocha-multi-reporters --reporter-options configFile=.multi.json",
     "start": "node index.js",
     "test:load": "artillery run load-test.yml",
     "swagger-autogen": "node ./swagger.js"
@@ -41,6 +41,8 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.2.0",
     "mocha": "^6.1.4",
+    "mocha-junit-reporter": "^2.0.2",
+    "mocha-multi-reporters": "^1.5.1",
     "nyc": "^15.1.0",
     "pre-push": "^0.1.1",
     "supertest": "^4.0.2",

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,27 @@
+const { createLogger, format, transports } = require('winston')
+const path = require('path')
+const LOGGING_LEVEL = 'info'
+const logger = createLogger({
+  level: LOGGING_LEVEL,
+  format: format.combine(
+    format.label({
+      label: path.basename(process.mainModule.filename)
+    }),
+    format.timestamp({
+      format: 'YYYY-MM-DD hh:mm:ss'
+    }),
+    format.printf(
+      (info) =>
+        `${info.timestamp} ${LOGGING_LEVEL} [${info.label}]: ${info.message}`
+    )
+  ),
+  transports: [
+    new transports.File({
+      filename: 'request.log',
+      handleExceptions: true
+    }),
+    new transports.Console()
+  ]
+})
+
+module.exports = logger

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -3,17 +3,12 @@
 const winston = require('winston')
 const expressWinston = require('express-winston')
 const helmet = require('helmet')
-const transports = [
-  new winston.transports.Console(),
-  new winston.transports.File({
-    filename: 'request.log'
-  })
-]
+const logger = require('./logger')
 module.exports.enableSecureHeader = (app) => app.use(helmet())
 module.exports.requestLogging = (app) =>
   app.use(
     expressWinston.logger({
-      transports: transports,
+      winstonInstance: logger,
       format: winston.format.combine(
         winston.format.colorize(),
         winston.format.json()
@@ -31,7 +26,7 @@ module.exports.requestLogging = (app) =>
 module.exports.errorLogging = (app) =>
   app.use(
     expressWinston.errorLogger({
-      transports: transports,
+      winstonInstance: logger,
       format: winston.format.combine(
         winston.format.colorize(),
         winston.format.json()

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -4,6 +4,7 @@ const request = require('supertest')
 const assert = require('assert')
 const sqlite3 = require('sqlite3').verbose()
 const { open } = require('sqlite')
+const logger = require('../src/logger')
 let db, app
 const buildSchemas = require('../src/schemas')
 const mainFake = {
@@ -28,6 +29,7 @@ const assertRide = function (actual, expect) {
 
 describe('API tests', () => {
   before(async () => {
+    logger.silent = true
     db = await open({
       filename: ':memory:',
       driver: sqlite3.Database


### PR DESCRIPTION
### Implement Tooling

Please implement the following tooling:

1. `eslint` - for linting
2. `nyc` - for code coverage
3. `pre-push` - for git pre push hook running tests
4. `winston` - for logging

#### Success Criteria

1. Create a pull request against `master` of your fork with the new tooling and merge it
   1. `eslint` should have an opinionated format
   2. `nyc` should aim for test coverage of `80%` across lines, statements, and branches
   3. `pre-push` should run the tests before allowing pushing using `git`
   4. `winston` should be used to replace console logs and all errors should be logged as well. Logs should go to disk.
2. Ensure that tooling is connected to `npm test`
3. Create a separate pull request against `master` of your fork with the linter fixes and merge it
4. Create a separate pull request against `master` of your fork to increase code coverage to acceptable thresholds and merge it
5. **[BONUS]** Add integration to CI such as Travis or Circle
6. **[BONUS]** Add Typescript support

## Add Circle CI with the basic test configuration
![image](https://user-images.githubusercontent.com/15000126/149654772-eb041851-4032-4869-a79f-7ce577bc3a0e.png)

## Improve logging
![image](https://user-images.githubusercontent.com/15000126/149654794-7e130e32-0963-4753-b24b-adfb0fcf406e.png)
